### PR TITLE
Use quay.io as the base image repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM docker.io/centos:centos8
-MAINTAINER mrunge
+FROM quay.io/centos/centos:centos8
 
 USER root
 
-RUN dnf -y update
 RUN dnf -y install centos-release-opstools
 RUN dnf -y install python3-cherrypy python3-PyYAML python3-pysnmp \
                    python3-dateutil python3-click git \
                    prometheus-webhook-snmp \
-                   python3-prometheus_client procps-ng telnet lsof && dnf clean all
+                   python3-prometheus_client procps-ng lsof && dnf clean all
 
 ENV SNMP_COMMUNITY="public"
 ENV SNMP_PORT="162"
@@ -22,5 +20,3 @@ EXPOSE 9099
 CMD exec /usr/bin/prometheus-webhook-snmp --debug --snmp-port=$SNMP_PORT \
   --snmp-host=$SNMP_HOST --snmp-community=$SNMP_COMMUNITY \
   --alert-oid-label=$ALERT_OID_LABEL run
-
-# buildah build-using-dockerfile -t "mrunge/prometheus-webhook-snmp" .


### PR DESCRIPTION
Use quay.io to avoid issues building from docker.io and quota overuse.

Drop deprecated MAINTAINER option. Remove unused commented line. Also
remove telnet package which is not necessary to the operation of this
container image.
