### PR TITLE
Remove invalid addition to requirements.txt (#11)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,6 @@ ply==3.11
 portend==2.7.1
     # via cherrypy
 prometheus_client==0.6.0
-pysnmp>=4.4.1
     # via -r requirements.in
 py==1.10.0
     # via pytest


### PR DESCRIPTION
When I rebased I inadvertently added an invalid reference which breaks
cachito. Imports require requirements.txt to be pinned to a version.

(cherry picked from commit 45d40c486903e220682e765ccd2f26878af6f56f)

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
