### PR TITLE
Bump actions checkout to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.3
 
       - name: Verify image builds
         run: docker build --tag infrawatch/prometheus-webhook-snmp:latest --file Dockerfile .


### PR DESCRIPTION
Bump actions checkout to v4 since Node.js 16 actions are deprecated. We need to update to Node.js 20, which is included in actions/checkout@v4.