### PR TITLE
Update GH actions to use ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
   build-check:
     name: Build check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.

Actions need to be updated to a newer version.

For some jobs we are already using ubuntu-latest, so use the same for the jobs using ubuntu20.04