### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches-ignore: [master, main]


### PR DESCRIPTION
Potential fix for [https://github.com/infrawatch/prometheus-webhook-snmp/security/code-scanning/2](https://github.com/infrawatch/prometheus-webhook-snmp/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that limits the default GITHUB_TOKEN permissions to only what these jobs require. Since the jobs only need to read the repository contents (for `actions/checkout` and for the linter/build to see the code) and do not appear to need to write to the repo or to issues/PRs, we can safely set `contents: read` at the workflow root. This will apply to all jobs that don’t override `permissions`.

The best, minimal-impact fix is to add a root-level `permissions:` section just after the `name: CI` line and before `on:` in `.github/workflows/main.yml`, with `contents: read`. This satisfies CodeQL’s requirement and GitHub’s security guidance, without changing any of the existing steps or their behavior: `actions/checkout` works with `contents: read`, and `github/super-linter` works with a read-only token when only linting. No additional imports or methods are needed; it’s purely a YAML configuration change in this workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
