### PR TITLE
Revert "Bump pip from 25.0.1 to 25.3"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -10,4 +10,4 @@ pyasn1==0.6.0
 pytest==8.3.5
 pytest-runner==6.0.1
 python_dateutil==2.9.0.post0
-pip==25.3
+pip==25.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,7 @@ zc-lockfile==3.0.post1
     # via cherrypy
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.0.1
     # via -r requirements.in
 setuptools==78.1.1
     # via zc-lockfile

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requirements = [
     'pytest==8.3.5',
     'pytest-runner==6.0.1',
     'python-dateutil==2.9.0.post0',
-    'pip==25.3',
+    'pip==25.0.1',
 ]
 
 dependency_links = [


### PR DESCRIPTION
In commit 2eab53f15f0655b91c9595f278a96571a0269580 we updated the pip version to 25.3 to address https://github.com/infrawatch/prometheus-webhook-snmp/security/dependabot/16

We don't use an impacted version of Python so we are not affected by this issue.

The change on the pip version generates dependencies issues.