### PR TITLE
Update requirements and requirements-build with security fixes

### DIFF
--- a/requirements-build-duplicates.txt
+++ b/requirements-build-duplicates.txt
@@ -5,10 +5,6 @@
 #
 setuptools-scm==7.1.0
     # via python-dateutil
-tomli==2.0.2
-    # via setuptools-scm
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==78.1.1
-    # via
-    #   python-dateutil
-    #   setuptools-scm
+    # via zc-lockfile

--- a/requirements-build.in
+++ b/requirements-build.in
@@ -16,7 +16,7 @@ coherent-licensed==0.5.2
     #   portend
     #   tempora
     #   zipp
-cython==3.2.4
+cython==3.2.8
     # via pyyaml
 flit-core==3.12.0
     # via
@@ -52,10 +52,11 @@ packaging==26.2
     # via
     #   hatchling
     #   setuptools-scm
+    #   vcs-versioning
     #   wheel
 pathspec==1.1.1
     # via hatchling
-pdm-backend==2.4.8
+pdm-backend==2.4.9
     # via
     #   annotated-doc
     #   typer
@@ -67,9 +68,7 @@ poetry-core==2.2.1
     #   pysnmp
     #   rich
     #   tomlkit
-# setuptools-scm==7.1.0
-#     # via python-dateutil
-setuptools-scm==9.2.2
+setuptools-scm==10.2.0
     # via
     #   backports-tarfile
     #   cheroot
@@ -88,16 +87,21 @@ setuptools-scm==9.2.2
     #   setuptools-scm
     #   tempora
     #   zipp
-# tomli==2.0.2
-#     # via setuptools-scm
+# setuptools-scm==7.1.0
+#     # via python-dateutil
 tomli==2.4.1
     # via
     #   flit-scm
     #   hatchling
     #   setuptools-scm
-trove-classifiers==2026.1.14.14
+    #   vcs-versioning
+trove-classifiers==2026.6.1.19
     # via hatchling
 typing-extensions==4.15.0
+    # via
+    #   setuptools-scm
+    #   vcs-versioning
+vcs-versioning==2.2.2
     # via setuptools-scm
 wheel==0.47.0
     # via
@@ -138,4 +142,5 @@ setuptools==82.0.1
     #   shellingham
     #   tempora
     #   trove-classifiers
+    #   vcs-versioning
     #   zipp

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -8,7 +8,7 @@ calver==2025.10.20
     # via -r requirements-build.in
 coherent-licensed==0.5.2
     # via -r requirements-build.in
-cython==3.2.4
+cython==3.2.8
     # via -r requirements-build.in
 flit-core==3.12.0
     # via
@@ -31,12 +31,13 @@ packaging==26.2
     #   -r requirements-build.in
     #   hatchling
     #   setuptools-scm
+    #   vcs-versioning
     #   wheel
 pathspec==1.1.1
     # via
     #   -r requirements-build.in
     #   hatchling
-pdm-backend==2.4.8
+pdm-backend==2.4.9
     # via -r requirements-build.in
 pluggy==1.6.0
     # via
@@ -44,7 +45,7 @@ pluggy==1.6.0
     #   hatchling
 poetry-core==2.2.1
     # via -r requirements-build.in
-setuptools-scm==9.2.2
+setuptools-scm==10.2.0
     # via
     #   -r requirements-build.in
     #   flit-scm
@@ -55,11 +56,17 @@ tomli==2.4.1
     #   flit-scm
     #   hatchling
     #   setuptools-scm
-trove-classifiers==2026.1.14.14
+    #   vcs-versioning
+trove-classifiers==2026.6.1.19
     # via
     #   -r requirements-build.in
     #   hatchling
 typing-extensions==4.15.0
+    # via
+    #   -r requirements-build.in
+    #   setuptools-scm
+    #   vcs-versioning
+vcs-versioning==2.2.2
     # via
     #   -r requirements-build.in
     #   setuptools-scm

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ prometheus_client==0.21.1
 pyfakefs==5.8.0
 pylint==3.3.6
 pysnmp==7.1.17
-pyasn1==0.6.3
+pyasn1==0.6.4
 pytest==8.3.5
 pytest-runner==6.0.1
 python_dateutil==2.9.0.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ portend==3.2.1
     # via cherrypy
 prometheus-client==0.21.1
     # via -r requirements.in
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -r requirements.in
     #   pysnmp

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
     'pyfakefs==5.8.0',
     'pylint==3.3.6',
     'pysnmp==7.1.17',
-    'pyasn1==0.6.3',
+    'pyasn1==0.6.4',
     'pytest==8.3.5',
     'pytest-runner==6.0.1',
     'python-dateutil==2.9.0.post0',


### PR DESCRIPTION
Security fixes:
- https://github.com/pyasn1/pyasn1/security/advisories/GHSA-8ppf-4f7h-5ppj: pyasn1 0.6.3 to 0.6.4 (CVE-2026-59885: quadratic OID decoding, CVE-2026-59884: unbounded BER tag IDs, CVE-2026-59886: Real.__float__() overflow)

Pre requirements:

    pip3 install pip-tools pybuild-deps

Steps to regenerate requirements files:
1. Edit requirements.in - set new package version
2. pip-compile requirements.in -o requirements.txt --allow-unsafe
3. pybuild-deps compile requirements.txt -o requirements-build.in --annotate
4. Find duplicate packages in requirements-build.in, keep latest version, comment out older ones and add them to requirements-build-duplicates.txt (e.g. setuptools-scm appears as both 10.2.0 and 7.1.0, setuptools as both 82.0.1 and 78.1.1 - keep latest uncommented, comment out older versions with # prefix)
5. pip-compile requirements-build.in -o requirements-build.txt --allow-unsafe
6. Update setup.py install_requires to match requirements.in

Related-To: OSPRH-32896
(cherry picked from commit f1e8db8b260cee1bd0dbd92b85ec10ae66525e41)